### PR TITLE
feat: the news page should also show the fields documenti and datasets

### DIFF
--- a/comuni_theme/config/sync/core.entity_view_display.node.notizia.default.yml
+++ b/comuni_theme/config/sync/core.entity_view_display.node.notizia.default.yml
@@ -76,10 +76,11 @@ content:
     weight: 107
     region: content
   field_dataset:
-    type: entity_reference_label
+    type: entity_reference_entity_view
     label: hidden
     settings:
-      link: true
+      view_mode: teaser
+      link: false
     third_party_settings: {  }
     weight: 116
     region: content

--- a/comuni_theme/templates/field/field--node--field-dataset--notizia.html.twig
+++ b/comuni_theme/templates/field/field--node--field-dataset--notizia.html.twig
@@ -1,0 +1,116 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+    'field',
+    'field--name-' ~ field_name|clean_class,
+    'field--type-' ~ field_type|clean_class,
+    'field--label-' ~ label_display,
+    label_display == 'inline' ? 'clearfix',
+  ]
+%}
+{%
+  set title_classes = [
+    'field__label',
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+<div class="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal">
+{% if label_hidden %}
+  {% if multiple %}
+      {% for item in items %}
+      <div class="card card-teaser shadow-sm p-4 mt-3 rounded border border-light flex-nowrap">
+        <svg class="icon" viewBox="0 0 24 24" id="it-clip" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M11 22a2.9 2.9 0 01-3-3V6a4 4 0 018 0v10h-1V6a3 3 0 00-6 0v13a2 2 0 004 0V8a1 1 0 00-2 0v8h-1V8a2 2 0 014 0v11a2.9 2.9 0 01-3 3z" />
+          <path fill="none" d="M0 0h24v24H0z" />
+        </svg>
+        {% set filename = item.content['#node'].title.value %}
+        <div class="card-body">
+          <h5 class="card-title">
+            <a href="{{ path('entity.node.canonical', { 'node': item.content['#node'].nid.value }) }}"
+              title="Naviga a {{ filename }}" aria-label="Naviga a {{ filename }}"
+              class="text-decoration-none"
+            >{{ filename }}
+            </a>
+          </h5>
+        </div>
+      </div>
+      {% endfor %}
+  {% else %}
+    {% for item in items %}
+      <div class="card card-teaser shadow-sm p-4 mt-3 rounded border border-light flex-nowrap">
+        <svg class="icon" viewBox="0 0 24 24" id="it-clip" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M11 22a2.9 2.9 0 01-3-3V6a4 4 0 018 0v10h-1V6a3 3 0 00-6 0v13a2 2 0 004 0V8a1 1 0 00-2 0v8h-1V8a2 2 0 014 0v11a2.9 2.9 0 01-3 3z" />
+          <path fill="none" d="M0 0h24v24H0z" />
+        </svg>
+        {% set filename = item.content['#node'].title.value %}
+        <div class="card-body">
+          <h5 class="card-title">
+            <a href="{{ path('entity.node.canonical', { 'node': item.content['#node'].nid.value }) }}"
+              title="Naviga a {{ filename }}" aria-label="Naviga a {{ filename }}"
+              class="text-decoration-none"
+            >{{ filename }}
+            </a>
+          </h5>
+        </div>
+      </div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+    {% for item in items %}
+      <div class="card card-teaser shadow-sm p-4 mt-3 rounded border border-light flex-nowrap">
+        <svg class="icon" viewBox="0 0 24 24" id="it-clip" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M11 22a2.9 2.9 0 01-3-3V6a4 4 0 018 0v10h-1V6a3 3 0 00-6 0v13a2 2 0 004 0V8a1 1 0 00-2 0v8h-1V8a2 2 0 014 0v11a2.9 2.9 0 01-3 3z" />
+          <path fill="none" d="M0 0h24v24H0z" />
+        </svg>
+        {% set filename = item.content['#node'].title.value %}
+        <div class="card-body">
+          <h5 class="card-title">
+            <a href="{{ path('entity.node.canonical', { 'node': item.content['#node'].nid.value }) }}"
+              title="Naviga a {{ filename }}" aria-label="Naviga a {{ filename }}"
+              class="text-decoration-none"
+            >{{ filename }}
+          </h5>
+        </div>
+      </div>
+    {% endfor %}
+{% endif %}
+</div>

--- a/comuni_theme/templates/field/field--node--field-documenti--notizia.html.twig
+++ b/comuni_theme/templates/field/field--node--field-documenti--notizia.html.twig
@@ -1,0 +1,116 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+    'field',
+    'field--name-' ~ field_name|clean_class,
+    'field--type-' ~ field_type|clean_class,
+    'field--label-' ~ label_display,
+    label_display == 'inline' ? 'clearfix',
+  ]
+%}
+{%
+  set title_classes = [
+    'field__label',
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+<div class="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal">
+{% if label_hidden %}
+  {% if multiple %}
+      {% for item in items %}
+      <div class="card card-teaser shadow-sm p-4 mt-3 rounded border border-light flex-nowrap">
+        <svg class="icon" viewBox="0 0 24 24" id="it-clip" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M11 22a2.9 2.9 0 01-3-3V6a4 4 0 018 0v10h-1V6a3 3 0 00-6 0v13a2 2 0 004 0V8a1 1 0 00-2 0v8h-1V8a2 2 0 014 0v11a2.9 2.9 0 01-3 3z" />
+          <path fill="none" d="M0 0h24v24H0z" />
+        </svg>
+        {% set filename = item.content['#node'].title.value %}
+        <div class="card-body">
+          <h5 class="card-title">
+            <a href="{{ path('entity.node.canonical', { 'node': item.content['#node'].nid.value }) }}"
+              title="Naviga a {{ filename }}" aria-label="Naviga a {{ filename }}"
+              class="text-decoration-none"
+            >{{ filename }}
+            </a>
+          </h5>
+        </div>
+      </div>
+      {% endfor %}
+  {% else %}
+    {% for item in items %}
+      <div class="card card-teaser shadow-sm p-4 mt-3 rounded border border-light flex-nowrap">
+        <svg class="icon" viewBox="0 0 24 24" id="it-clip" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M11 22a2.9 2.9 0 01-3-3V6a4 4 0 018 0v10h-1V6a3 3 0 00-6 0v13a2 2 0 004 0V8a1 1 0 00-2 0v8h-1V8a2 2 0 014 0v11a2.9 2.9 0 01-3 3z" />
+          <path fill="none" d="M0 0h24v24H0z" />
+        </svg>
+        {% set filename = item.content['#node'].title.value %}
+        <div class="card-body">
+          <h5 class="card-title">
+            <a href="{{ path('entity.node.canonical', { 'node': item.content['#node'].nid.value }) }}"
+              title="Naviga a {{ filename }}" aria-label="Naviga a {{ filename }}"
+              class="text-decoration-none"
+            >{{ filename }}
+            </a>
+          </h5>
+        </div>
+      </div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+    {% for item in items %}
+      <div class="card card-teaser shadow-sm p-4 mt-3 rounded border border-light flex-nowrap">
+        <svg class="icon" viewBox="0 0 24 24" id="it-clip" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M11 22a2.9 2.9 0 01-3-3V6a4 4 0 018 0v10h-1V6a3 3 0 00-6 0v13a2 2 0 004 0V8a1 1 0 00-2 0v8h-1V8a2 2 0 014 0v11a2.9 2.9 0 01-3 3z" />
+          <path fill="none" d="M0 0h24v24H0z" />
+        </svg>
+        {% set filename = item.content['#node'].title.value %}
+        <div class="card-body">
+          <h5 class="card-title">
+            <a href="{{ path('entity.node.canonical', { 'node': item.content['#node'].nid.value }) }}"
+              title="Naviga a {{ filename }}" aria-label="Naviga a {{ filename }}"
+              class="text-decoration-none"
+            >{{ filename }}
+          </h5>
+        </div>
+      </div>
+    {% endfor %}
+{% endif %}
+</div>

--- a/comuni_theme/templates/node/node--notizia.html.twig
+++ b/comuni_theme/templates/node/node--notizia.html.twig
@@ -223,6 +223,13 @@
                             </a>
                           </li>
                           {% endif %}
+                          {% if node.field_documenti[0] is not empty %}
+                          <li class="nav-item">
+                            <a class="nav-link" href="#documenti">
+                              <span class="title-medium">Documenti</span>
+                            </a>
+                          </li>
+                          {% endif %}
                           {% if node.field_allegati[0] is not empty %}
                           <li class="nav-item">
                             <a class="nav-link" href="#allegati">
@@ -234,13 +241,6 @@
                           <li class="nav-item">
                             <a class="nav-link" href="#dataset">
                               <span class="title-medium">Dataset</span>
-                            </a>
-                          </li>
-                          {% endif %}
-                          {% if node.field_documenti[0] is not empty %}
-                          <li class="nav-item">
-                            <a class="nav-link" href="#documenti">
-                              <span class="title-medium">Documenti</span>
                             </a>
                           </li>
                           {% endif %}
@@ -279,6 +279,12 @@
 
         </article>
       {% endif %}
+      {% if content.field_documenti[0] is not empty %}
+        <article id="documenti" class="it-page-section anchor-offset mt-5">
+          <h4>Documenti</h4>
+          {{ content.field_documenti }}
+        </article>
+      {% endif %}
       {% if content.field_allegati[0] is not empty %}
         <article id="allegati" class="it-page-section anchor-offset mt-5">
           <h4>Allegati</h4>
@@ -289,12 +295,6 @@
         <article id="dataset" class="it-page-section anchor-offset mt-5">
           <h4>Dataset</h4>
           {{ content.field_dataset }}
-        </article>
-      {% endif %}
-      {% if content.field_documenti[0] is not empty %}
-        <article id="documenti" class="it-page-section anchor-offset mt-5">
-          <h4>Documenti</h4>
-          {{ content.field_documenti }}
         </article>
       {% endif %}
       {% if content.field_a_cura_di[0] is not empty %}

--- a/comuni_theme/templates/node/node--notizia.html.twig
+++ b/comuni_theme/templates/node/node--notizia.html.twig
@@ -272,7 +272,7 @@
     <section class="col-lg-8 it-page-sections-container border-light">
       {% if content.field_testo_completo_notizia [0] is not empty %}
         <article id="descrizione" class="it-page-section anchor-offset" data-audio>
-          <h4>Descrizione</h4>{# TODO Label #}
+          <h2 class="mb-3">Descrizione</h2>{# TODO Label #}
           <div class="font-serif">
             {{ content.field_testo_completo_notizia }}
           </div>
@@ -281,25 +281,25 @@
       {% endif %}
       {% if content.field_documenti[0] is not empty %}
         <article id="documenti" class="it-page-section anchor-offset mt-5">
-          <h4>Documenti</h4>
+          <h2 class="mb-3">Documenti</h2>
           {{ content.field_documenti }}
         </article>
       {% endif %}
       {% if content.field_allegati[0] is not empty %}
         <article id="allegati" class="it-page-section anchor-offset mt-5">
-          <h4>Allegati</h4>
+          <h2 class="mb-3">Allegati</h2>
           {{ content.field_allegati }}
         </article>
       {% endif %}
       {% if content.field_dataset[0] is not empty %}
         <article id="dataset" class="it-page-section anchor-offset mt-5">
-          <h4>Dataset</h4>
+          <h2 class="mb-3">Dataset</h2>
           {{ content.field_dataset }}
         </article>
       {% endif %}
       {% if content.field_a_cura_di[0] is not empty %}
         <article id="a-cura-di" class="it-page-section anchor-offset mt-5">
-          <h4>A cura di</h4>
+          <h2 class="mb-3">A cura di</h2>
           <div class="row">
             <div class="col-12 col-sm-8">
               <p class="h6">

--- a/comuni_theme/templates/node/node--notizia.html.twig
+++ b/comuni_theme/templates/node/node--notizia.html.twig
@@ -225,6 +225,20 @@
                           {% endif %}
                           {% if node.field_allegati[0] is not empty %}
                           <li class="nav-item">
+                            <a class="nav-link" href="#allegati">
+                              <span class="title-medium">Allegati</span>
+                            </a>
+                          </li>
+                          {% endif %}
+                          {% if node.field_dataset[0] is not empty %}
+                          <li class="nav-item">
+                            <a class="nav-link" href="#dataset">
+                              <span class="title-medium">Dataset</span>
+                            </a>
+                          </li>
+                          {% endif %}
+                          {% if node.field_documenti[0] is not empty %}
+                          <li class="nav-item">
                             <a class="nav-link" href="#documenti">
                               <span class="title-medium">Documenti</span>
                             </a>
@@ -266,9 +280,21 @@
         </article>
       {% endif %}
       {% if content.field_allegati[0] is not empty %}
+        <article id="allegati" class="it-page-section anchor-offset mt-5">
+          <h4>Allegati</h4>
+          {{ content.field_allegati }}
+        </article>
+      {% endif %}
+      {% if content.field_dataset[0] is not empty %}
+        <article id="dataset" class="it-page-section anchor-offset mt-5">
+          <h4>Dataset</h4>
+          {{ content.field_dataset }}
+        </article>
+      {% endif %}
+      {% if content.field_documenti[0] is not empty %}
         <article id="documenti" class="it-page-section anchor-offset mt-5">
           <h4>Documenti</h4>
-          {{ content.field_allegati }}
+          {{ content.field_documenti }}
         </article>
       {% endif %}
       {% if content.field_a_cura_di[0] is not empty %}


### PR DESCRIPTION
news details show fields documenti and datasets (solves [#18 ](https://github.com/italia/design-comuni-drupal-theme/issues/18))