### PR TITLE
Fix vista comuni_in_evidenza

### DIFF
--- a/comuni_theme/config/sync/views.view.comuni_in_evidenza.yml
+++ b/comuni_theme/config/sync/views.view.comuni_in_evidenza.yml
@@ -194,44 +194,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        field_in_evidenza_value:
-          id: field_in_evidenza_value
-          table: node__field_in_evidenza
-          field: field_in_evidenza_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       style:
         type: default
       row:
@@ -337,44 +299,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        field_in_evidenza_value:
-          id: field_in_evidenza_value
-          table: node__field_in_evidenza
-          field: field_in_evidenza_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -454,44 +378,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        field_in_evidenza_value:
-          id: field_in_evidenza_value
-          table: node__field_in_evidenza
-          field: field_in_evidenza_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -559,44 +445,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        field_in_evidenza_value:
-          id: field_in_evidenza_value
-          table: node__field_in_evidenza
-          field: field_in_evidenza_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
           is_grouped: false
           group_info:
             label: ''


### PR DESCRIPTION
Ciao,
abbiamo rilevato un errore in una vista (in tutti i suoi display),
manca un campo che inizialmente era usato come filtro ma che non è più presente nei campi di drupal che avete creato per il template.
Abbiamo rimosso il filtro.
![1](https://user-images.githubusercontent.com/103657056/217011227-7626c06a-536d-4a8d-bec7-36bb98dfc7c2.png)
![2](https://user-images.githubusercontent.com/103657056/217011234-71beeb1f-08a8-47c0-b62c-469ce9f4d9ca.png)
